### PR TITLE
 Added params MySqlParameter[] to ExecuteQuery

### DIFF
--- a/DatabaseMgr.cs
+++ b/DatabaseMgr.cs
@@ -60,7 +60,7 @@ namespace ZaupShop
         {
             var affected = ExecuteQuery(false,
                 change
-                    ? $"update `{ZaupShop.Instance.Configuration.Instance.ItemShopTableName}` set itemname='{name}', cost='{cost}' where id='{id}';"
+                    ? $"update `{ZaupShop.Instance.Configuration.Instance.ItemShopTableName}` set itemname=@name, cost='{cost}' where id='{id}';"
                     : $"Insert into `{ZaupShop.Instance.Configuration.Instance.ItemShopTableName}` (`id`, `itemname`, `cost`) VALUES ('{id}', @name, '{cost}');",
                 new MySqlParameter("@name", name));
 
@@ -75,7 +75,7 @@ namespace ZaupShop
         {
             var affected = ExecuteQuery(false,
                 change
-                    ? $"update `{ZaupShop.Instance.Configuration.Instance.VehicleShopTableName}` set vehiclename='{name}', cost='{cost}' where id='{id}';"
+                    ? $"update `{ZaupShop.Instance.Configuration.Instance.VehicleShopTableName}` set vehiclename=@name, cost='{cost}' where id='{id}';"
                     : $"Insert into `{ZaupShop.Instance.Configuration.Instance.VehicleShopTableName}` (`id`, `vehiclename`, `cost`) VALUES ('{id}', @name, '{cost}');",
                 new MySqlParameter("@name", name));
 


### PR DESCRIPTION
This solves an issue when adding an item like `Hell's Fury`: `You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 's Fury', '8000')' at line 1`
This should also work just fine for any other item names which may have caused conflicts with the queries.